### PR TITLE
Braces overhaul

### DIFF
--- a/06-mutex/esp32-freertos-06-challenge-task-parameters/esp32-freertos-06-challenge-task-parameters.ino
+++ b/06-mutex/esp32-freertos-06-challenge-task-parameters/esp32-freertos-06-challenge-task-parameters.ino
@@ -9,7 +9,7 @@
  */
 
 // You'll likely need this on vanilla FreeRTOS
-//#include semphr.h
+//#include <semphr.h>
 
 // Use only core 1 for demo purposes
 #if CONFIG_FREERTOS_UNICORE

--- a/06-mutex/esp32-freertos-06-demo-mutex/esp32-freertos-06-demo-mutex.ino
+++ b/06-mutex/esp32-freertos-06-demo-mutex/esp32-freertos-06-demo-mutex.ino
@@ -9,7 +9,7 @@
  */
 
 // You'll likely need this on vanilla FreeRTOS
-//#include semphr.h
+//#include <semphr.h>
 
 // Use only core 1 for demo purposes
 #if CONFIG_FREERTOS_UNICORE

--- a/06-mutex/esp32-freertos-06-solution-task-parameters/esp32-freertos-06-solution-task-parameters.ino
+++ b/06-mutex/esp32-freertos-06-solution-task-parameters/esp32-freertos-06-solution-task-parameters.ino
@@ -9,7 +9,7 @@
  */
 
 // You'll likely need this on vanilla FreeRTOS
-//#include semphr.h
+//#include <semphr.h>
 
 // Use only core 1 for demo purposes
 #if CONFIG_FREERTOS_UNICORE

--- a/07-semaphore/esp32-freertos-07-challenge-counting-semaphore/esp32-freertos-07-challenge-counting-semaphore.ino
+++ b/07-semaphore/esp32-freertos-07-challenge-counting-semaphore/esp32-freertos-07-challenge-counting-semaphore.ino
@@ -15,7 +15,7 @@
  */
 
 // You'll likely need this on vanilla FreeRTOS
-//#include semphr.h
+//#include <semphr.h>
 
 // Use only core 1 for demo purposes
 #if CONFIG_FREERTOS_UNICORE

--- a/07-semaphore/esp32-freertos-07-demo-binary-semaphore/esp32-freertos-07-demo-binary-semaphore.ino
+++ b/07-semaphore/esp32-freertos-07-demo-binary-semaphore/esp32-freertos-07-demo-binary-semaphore.ino
@@ -9,7 +9,7 @@
  */
  
 // You'll likely need this on vanilla FreeRTOS
-//#include semphr.h
+//#include <semphr.h>
 
 // Use only core 1 for demo purposes
 #if CONFIG_FREERTOS_UNICORE

--- a/07-semaphore/esp32-freertos-07-demo-counting-semaphore/esp32-freertos-07-demo-counting-semaphore.ino
+++ b/07-semaphore/esp32-freertos-07-demo-counting-semaphore/esp32-freertos-07-demo-counting-semaphore.ino
@@ -10,7 +10,7 @@
  */
 
 // You'll likely need this on vanilla FreeRTOS
-//#include semphr.h
+//#include <semphr.h>
 
 // Use only core 1 for demo purposes
 #if CONFIG_FREERTOS_UNICORE

--- a/07-semaphore/esp32-freertos-07-solution-alt-queue/esp32-freertos-07-solution-alt-queue.ino
+++ b/07-semaphore/esp32-freertos-07-solution-alt-queue/esp32-freertos-07-solution-alt-queue.ino
@@ -10,7 +10,7 @@
  */
 
 // You'll likely need this on vanilla FreeRTOS
-//#include semphr.h
+//#include <semphr.h>
 
 // Use only core 1 for demo purposes
 #if CONFIG_FREERTOS_UNICORE

--- a/07-semaphore/esp32-freertos-07-solution-counting-semaphore/esp32-freertos-07-solution-counting-semaphore.ino
+++ b/07-semaphore/esp32-freertos-07-solution-counting-semaphore/esp32-freertos-07-solution-counting-semaphore.ino
@@ -10,7 +10,7 @@
  */
 
 // You'll likely need this on vanilla FreeRTOS
-//#include semphr.h
+//#include <semphr.h>
 
 // Use only core 1 for demo purposes
 #if CONFIG_FREERTOS_UNICORE

--- a/08-software-timer/esp32-freertos-08-demo-software-timer/esp32-freertos-08-demo-software-timer.ino
+++ b/08-software-timer/esp32-freertos-08-demo-software-timer/esp32-freertos-08-demo-software-timer.ino
@@ -9,7 +9,7 @@
  */
 
 // You'll likely need this on vanilla FreeRTOS
-//#include timers.h
+//#include <timers.h>
 
 // Use only core 1 for demo purposes
 #if CONFIG_FREERTOS_UNICORE

--- a/08-software-timer/esp32-freertos-08-solution-led-dimmer/esp32-freertos-08-solution-led-dimmer.ino
+++ b/08-software-timer/esp32-freertos-08-solution-led-dimmer/esp32-freertos-08-solution-led-dimmer.ino
@@ -10,7 +10,7 @@
  */
 
 // You'll likely need this on vanilla FreeRTOS
-//#include timers.h
+//#include <timers.h>
 
 // Use only core 1 for demo purposes
 #if CONFIG_FREERTOS_UNICORE

--- a/09-hardware-interrupts/esp32-freertos-09-demo-isr-semaphore/esp32-freertos-09-demo-isr-semaphore.ino
+++ b/09-hardware-interrupts/esp32-freertos-09-demo-isr-semaphore/esp32-freertos-09-demo-isr-semaphore.ino
@@ -9,7 +9,7 @@
  */
 
 // You'll likely need this on vanilla FreeRTOS
-//#include semphr.h
+//#include <semphr.h>
 
 // Use only core 1 for demo purposes
 #if CONFIG_FREERTOS_UNICORE

--- a/09-hardware-interrupts/esp32-freertos-09-solution-isr-audio/esp32-freertos-09-solution-isr-audio.ino
+++ b/09-hardware-interrupts/esp32-freertos-09-solution-isr-audio/esp32-freertos-09-solution-isr-audio.ino
@@ -9,7 +9,7 @@
  */
 
 // You'll likely need this on vanilla FreeRTOS
-//#include semphr.h
+//#include <semphr.h>
 
 // Use only core 1 for demo purposes
 #if CONFIG_FREERTOS_UNICORE

--- a/09-hardware-interrupts/esp32-freertos-09-solution-isr-sample/esp32-freertos-09-solution-isr-sample.ino
+++ b/09-hardware-interrupts/esp32-freertos-09-solution-isr-sample/esp32-freertos-09-solution-isr-sample.ino
@@ -9,7 +9,7 @@
  */
 
 // You'll likely need this on vanilla FreeRTOS
-//#include semphr.h
+//#include <semphr.h>
 
 // Use only core 1 for demo purposes
 #if CONFIG_FREERTOS_UNICORE

--- a/10-deadlock/esp32-freertos-10-challenge-dining-philosophers/esp32-freertos-10-challenge-dining-philosophers.ino
+++ b/10-deadlock/esp32-freertos-10-challenge-dining-philosophers/esp32-freertos-10-challenge-dining-philosophers.ino
@@ -11,7 +11,7 @@
  */
 
 // You'll likely need this on vanilla FreeRTOS
-//#include semphr.h
+//#include <semphr.h>
 
 // Use only core 1 for demo purposes
 #if CONFIG_FREERTOS_UNICORE

--- a/10-deadlock/esp32-freertos-10-demo-deadlock-hierarchy/esp32-freertos-10-demo-deadlock-hierarchy.ino
+++ b/10-deadlock/esp32-freertos-10-demo-deadlock-hierarchy/esp32-freertos-10-demo-deadlock-hierarchy.ino
@@ -11,7 +11,7 @@
  */
 
 // You'll likely need this on vanilla FreeRTOS
-//#include semphr.h
+//#include <semphr.h>
 
 // Use only core 1 for demo purposes
 #if CONFIG_FREERTOS_UNICORE

--- a/10-deadlock/esp32-freertos-10-demo-deadlock-timeout/esp32-freertos-10-demo-deadlock-timeout.ino
+++ b/10-deadlock/esp32-freertos-10-demo-deadlock-timeout/esp32-freertos-10-demo-deadlock-timeout.ino
@@ -10,7 +10,7 @@
  */
 
 // You'll likely need this on vanilla FreeRTOS
-//#include semphr.h
+//#include <semphr.h>
 
 // Use only core 1 for demo purposes
 #if CONFIG_FREERTOS_UNICORE

--- a/10-deadlock/esp32-freertos-10-demo-deadlock/esp32-freertos-10-demo-deadlock.ino
+++ b/10-deadlock/esp32-freertos-10-demo-deadlock/esp32-freertos-10-demo-deadlock.ino
@@ -9,7 +9,7 @@
  */
 
 // You'll likely need this on vanilla FreeRTOS
-//#include semphr.h
+//#include <semphr.h>
 
 // Use only core 1 for demo purposes
 #if CONFIG_FREERTOS_UNICORE

--- a/10-deadlock/esp32-freertos-10-solution-dining-philosophers-arbitrator/esp32-freertos-10-solution-dining-philosophers-arbitrator.ino
+++ b/10-deadlock/esp32-freertos-10-solution-dining-philosophers-arbitrator/esp32-freertos-10-solution-dining-philosophers-arbitrator.ino
@@ -11,7 +11,7 @@
  */
 
 // You'll likely need this on vanilla FreeRTOS
-//#include semphr.h
+//#include <semphr.h>
 
 // Use only core 1 for demo purposes
 #if CONFIG_FREERTOS_UNICORE

--- a/10-deadlock/esp32-freertos-10-solution-dining-philosophers-hierarchy/esp32-freertos-10-solution-dining-philosophers-hierarchy.ino
+++ b/10-deadlock/esp32-freertos-10-solution-dining-philosophers-hierarchy/esp32-freertos-10-solution-dining-philosophers-hierarchy.ino
@@ -11,7 +11,7 @@
  */
 
 // You'll likely need this on vanilla FreeRTOS
-//#include semphr.h
+//#include <semphr.h>
 
 // Use only core 1 for demo purposes
 #if CONFIG_FREERTOS_UNICORE

--- a/11-priority-inversion/esp32-freertos-11-demo-priority-inheritance/esp32-freertos-11-demo-priority-inheritance.ino
+++ b/11-priority-inversion/esp32-freertos-11-demo-priority-inheritance/esp32-freertos-11-demo-priority-inheritance.ino
@@ -9,7 +9,7 @@
  */
 
 // You'll likely need this on vanilla FreeRTOS
-//#include semphr.h
+//#include <semphr.h>
 
 // Use only core 1 for demo purposes
 #if CONFIG_FREERTOS_UNICORE

--- a/11-priority-inversion/esp32-freertos-11-demo-priority-inversion/esp32-freertos-11-demo-priority-inversion.ino
+++ b/11-priority-inversion/esp32-freertos-11-demo-priority-inversion/esp32-freertos-11-demo-priority-inversion.ino
@@ -9,7 +9,7 @@
  */
 
 // You'll likely need this on vanilla FreeRTOS
-//#include semphr.h
+//#include <semphr.h>
 
 // Use only core 1 for demo purposes
 #if CONFIG_FREERTOS_UNICORE

--- a/11-priority-inversion/esp32-freertos-11-solution-critical-section/esp32-freertos-11-solution-critical-section.ino
+++ b/11-priority-inversion/esp32-freertos-11-solution-critical-section/esp32-freertos-11-solution-critical-section.ino
@@ -10,7 +10,7 @@
  */
 
 // You'll likely need this on vanilla FreeRTOS
-//#include semphr.h
+//#include <semphr.h>
 
 // Use only core 1 for demo purposes
 #if CONFIG_FREERTOS_UNICORE


### PR DESCRIPTION
Timer and semaphore includes for vanilla FreeRTOS require braces.
This commit fixes the lack of braces.
Now it should compile.