### PR TITLE
Added taskYield() after unlocking the mutex, shortend taskname parameter string

### DIFF
--- a/06-mutex/esp32-freertos-06-demo-mutex/esp32-freertos-06-demo-mutex.ino
+++ b/06-mutex/esp32-freertos-06-demo-mutex/esp32-freertos-06-demo-mutex.ino
@@ -49,6 +49,7 @@ void incTask(void *parameters) {
   
       // Give mutex after critical section
       xSemaphoreGive(mutex);
+      taskYIELD();  // give the other task a chance to run
 
     } else {
       // Do something else
@@ -77,7 +78,7 @@ void setup() {
 
   // Start task 1
   xTaskCreatePinnedToCore(incTask,
-                          "Increment Task 1",
+                          "IncTask 1",  // Note: max length of taskname parameter is 16 (including '\0')
                           1024,
                           NULL,
                           1,
@@ -86,7 +87,7 @@ void setup() {
 
   // Start task 2
   xTaskCreatePinnedToCore(incTask,
-                          "Increment Task 2",
+                          "IncTask 2",   // Note: max length of taskname parameter is 16 (including '\0')
                           1024,
                           NULL,
                           1,

--- a/06-mutex/esp32-freertos-06-demo-mutex/esp32-freertos-06-demo-mutex.ino
+++ b/06-mutex/esp32-freertos-06-demo-mutex/esp32-freertos-06-demo-mutex.ino
@@ -45,6 +45,7 @@ void incTask(void *parameters) {
       // Print out new shared variable
       // This is different than in the video--print shared_var inside the
       // critical section to avoid having it be changed by the other task.
+      Serial.print(pcTaskGetName(NULL)); Serial.print(" : ");
       Serial.println(shared_var);
   
       // Give mutex after critical section


### PR DESCRIPTION
taskYield() was added after releasing the mutex, so that task2 can run,
a control output was added to log the active task's name,
the taskname string parameter was shortened to fit the 16 byte default size limit.